### PR TITLE
Migrating pre 1.12 Android project

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,19 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="co.appbrewery.quizzler">
 
-    <!-- The INTERNET permission is required for development. Specifically,
-         flutter needs it to communicate with the running application
-         to allow setting breakpoints, to provide hot reload, etc.
-    -->
     <uses-permission android:name="android.permission.INTERNET"/>
 
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
-         In most cases you can leave this as-is, but you if you want to provide
-         additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
         android:label="quizzler"
         android:icon="@mipmap/ic_launcher">
         <activity
@@ -23,17 +13,20 @@
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
-            <!-- This keeps the window background of the activity showing
-                 until Flutter renders its first frame. It can be removed if
-                 there is no splash screen (such as the default splash screen
-                 defined in @style/LaunchTheme). -->
             <meta-data
-                android:name="io.flutter.app.android.SplashScreenUntilFirstFrame"
-                android:value="true" />
+                android:name="io.flutter.embedding.android.SplashScreenDrawable"
+                android:resource="@drawable/launch_background" />
+            <meta-data
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme"
+                />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/android/app/src/main/java/co/appbrewery/quizzler/MainActivity.java
+++ b/android/app/src/main/java/co/appbrewery/quizzler/MainActivity.java
@@ -1,13 +1,6 @@
 package co.appbrewery.quizzler;
 
-import android.os.Bundle;
-import io.flutter.app.FlutterActivity;
-import io.flutter.plugins.GeneratedPluginRegistrant;
+import io.flutter.embedding.android.FlutterActivity;
 
 public class MainActivity extends FlutterActivity {
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
-  }
 }

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
-        <!-- Show a splash screen on the activity. Automatically removed when
-             Flutter draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
+    </style>
+    <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
+        <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>

--- a/ios/Flutter/flutter_export_environment.sh
+++ b/ios/Flutter/flutter_export_environment.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# This is a generated file; do not edit or check into version control.
+export "FLUTTER_ROOT=C:\src\flutter"
+export "FLUTTER_APPLICATION_PATH=E:\Flutter\AndroidStudioProjects\quizzler-flutter"
+export "FLUTTER_TARGET=lib\main.dart"
+export "FLUTTER_BUILD_DIR=build"
+export "SYMROOT=${SOURCE_ROOT}/../build\ios"
+export "FLUTTER_BUILD_NAME=1.0.0"
+export "FLUTTER_BUILD_NUMBER=1"
+export "DART_OBFUSCATION=false"
+export "TRACK_WIDGET_CREATION=false"
+export "TREE_SHAKE_ICONS=false"
+export "PACKAGE_CONFIG=.packages"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:quizzler/question.dart';
+import 'question.dart';
 
 void main() => runApp(Quizzler());
 
@@ -6,6 +8,7 @@ class Quizzler extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      debugShowCheckedModeBanner: false,
       home: Scaffold(
         backgroundColor: Colors.grey.shade900,
         body: SafeArea(
@@ -25,6 +28,37 @@ class QuizPage extends StatefulWidget {
 }
 
 class _QuizPageState extends State<QuizPage> {
+  List<Icon> scoreKeeper = [];
+
+  // List<String> questions = [
+  //   'You can lead a cow down stairs but not up stairs.',
+  //   'Approximately one quarter of human bones are in the feet.',
+  //   'A slug\'s blood is green.'
+  // ];
+  //
+  // List<bool> answers = [false, true, true];
+  //
+  // Question q1 = Question(
+  //   q: 'You can lead a cow down stairs but not up stairs.', a: false,
+  // );
+
+  List<Question> questionBank = [
+    Question(
+      q: 'You can lead a cow down stairs but not up stairs.',
+      a: false,
+    ),
+    Question(
+      q: 'Approximately one quarter of human bones are in the feet.',
+      a: true,
+    ),
+    Question(
+      q: 'A slug\'s blood is green.',
+      a: true,
+    ),
+  ];
+
+  int questionNo = 0;
+
   @override
   Widget build(BuildContext context) {
     return Column(
@@ -37,7 +71,7 @@ class _QuizPageState extends State<QuizPage> {
             padding: EdgeInsets.all(10.0),
             child: Center(
               child: Text(
-                'This is where the question text will go.',
+                questionBank[questionNo].questionText,
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   fontSize: 25.0,
@@ -49,10 +83,12 @@ class _QuizPageState extends State<QuizPage> {
         ),
         Expanded(
           child: Padding(
-            padding: EdgeInsets.all(15.0),
-            child: FlatButton(
-              textColor: Colors.white,
-              color: Colors.green,
+            padding: const EdgeInsets.all(15.0),
+            child: TextButton(
+              style: TextButton.styleFrom(
+                backgroundColor: Colors.green,
+                //textStyle: TextStyle(color: Colors.white),
+              ),
               child: Text(
                 'True',
                 style: TextStyle(
@@ -61,32 +97,60 @@ class _QuizPageState extends State<QuizPage> {
                 ),
               ),
               onPressed: () {
-                //The user picked true.
+                setState(() {
+                  bool correctAnswer = questionBank[questionNo].questionAnswer;
+                  if (correctAnswer == true) {
+                    print('User got it right');
+                  } else {
+                    print('User got it wrong');
+                  }
+                  questionNo++;
+                });
               },
             ),
           ),
         ),
         Expanded(
           child: Padding(
-            padding: EdgeInsets.all(15.0),
+            padding: const EdgeInsets.all(15.0),
             child: TextButton(
               style: TextButton.styleFrom(
                 backgroundColor: Colors.red,
+                //textStyle: TextStyle(color: Colors.white),
               ),
               child: Text(
                 'False',
                 style: TextStyle(
-                  fontSize: 20.0,
                   color: Colors.white,
+                  fontSize: 20.0,
                 ),
               ),
               onPressed: () {
-                //The user picked false.
+                bool correctAnswer = questionBank[questionNo].questionAnswer;
+                if (correctAnswer == false) {
+                  print('User got it right');
+                } else {
+                  print('User got it wrong');
+                }
+                setState(() {
+                  questionNo++;
+                });
               },
             ),
           ),
         ),
-        //TODO: Add a Row here as your score keeper
+        Row(
+          children: [
+            Icon(
+              Icons.check,
+              color: Colors.green,
+            ),
+            Icon(
+              Icons.close,
+              color: Colors.red,
+            )
+          ],
+        )
       ],
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:quizzler/question.dart';
-import 'question.dart';
+import 'package:quizzler/quiz_brain.dart';
+
+QuizBrain quizBrain = QuizBrain();
 
 void main() => runApp(Quizzler());
 
@@ -30,34 +31,17 @@ class QuizPage extends StatefulWidget {
 class _QuizPageState extends State<QuizPage> {
   List<Icon> scoreKeeper = [];
 
-  // List<String> questions = [
-  //   'You can lead a cow down stairs but not up stairs.',
-  //   'Approximately one quarter of human bones are in the feet.',
-  //   'A slug\'s blood is green.'
-  // ];
-  //
-  // List<bool> answers = [false, true, true];
-  //
-  // Question q1 = Question(
-  //   q: 'You can lead a cow down stairs but not up stairs.', a: false,
-  // );
-
-  List<Question> questionBank = [
-    Question(
-      q: 'You can lead a cow down stairs but not up stairs.',
-      a: false,
-    ),
-    Question(
-      q: 'Approximately one quarter of human bones are in the feet.',
-      a: true,
-    ),
-    Question(
-      q: 'A slug\'s blood is green.',
-      a: true,
-    ),
-  ];
-
-  int questionNo = 0;
+  void checkAnswer(bool usersAnswer) {
+    bool correctAnswer = quizBrain.getAnswerText();
+    setState(() {
+      if (usersAnswer == correctAnswer) {
+        scoreKeeper.add(Icon(Icons.check, color: Colors.green));
+      } else {
+        scoreKeeper.add(Icon(Icons.close, color: Colors.red));
+      }
+      quizBrain.nextQuestion();
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -71,7 +55,7 @@ class _QuizPageState extends State<QuizPage> {
             padding: EdgeInsets.all(10.0),
             child: Center(
               child: Text(
-                questionBank[questionNo].questionText,
+                quizBrain.getQuestionText(),
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   fontSize: 25.0,
@@ -97,15 +81,7 @@ class _QuizPageState extends State<QuizPage> {
                 ),
               ),
               onPressed: () {
-                setState(() {
-                  bool correctAnswer = questionBank[questionNo].questionAnswer;
-                  if (correctAnswer == true) {
-                    print('User got it right');
-                  } else {
-                    print('User got it wrong');
-                  }
-                  questionNo++;
-                });
+                checkAnswer(true);
               },
             ),
           ),
@@ -126,30 +102,13 @@ class _QuizPageState extends State<QuizPage> {
                 ),
               ),
               onPressed: () {
-                bool correctAnswer = questionBank[questionNo].questionAnswer;
-                if (correctAnswer == false) {
-                  print('User got it right');
-                } else {
-                  print('User got it wrong');
-                }
-                setState(() {
-                  questionNo++;
-                });
+                checkAnswer(false);
               },
             ),
           ),
         ),
         Row(
-          children: [
-            Icon(
-              Icons.check,
-              color: Colors.green,
-            ),
-            Icon(
-              Icons.close,
-              color: Colors.red,
-            )
-          ],
+          children: scoreKeeper,
         )
       ],
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -69,8 +69,10 @@ class _QuizPageState extends State<QuizPage> {
         Expanded(
           child: Padding(
             padding: EdgeInsets.all(15.0),
-            child: FlatButton(
-              color: Colors.red,
+            child: TextButton(
+              style: TextButton.styleFrom(
+                backgroundColor: Colors.red,
+              ),
               child: Text(
                 'False',
                 style: TextStyle(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:quizzler/quiz_brain.dart';
+import 'package:rflutter_alert/rflutter_alert.dart';
 
 QuizBrain quizBrain = QuizBrain();
 
@@ -34,12 +35,19 @@ class _QuizPageState extends State<QuizPage> {
   void checkAnswer(bool usersAnswer) {
     bool correctAnswer = quizBrain.getAnswerText();
     setState(() {
-      if (usersAnswer == correctAnswer) {
-        scoreKeeper.add(Icon(Icons.check, color: Colors.green));
+      if (quizBrain.isFinished() == true) {
+        Alert(context: context, title: "ALERT", desc: "End of Questions")
+            .show();
+        quizBrain.reset();
+        scoreKeeper.clear();
       } else {
-        scoreKeeper.add(Icon(Icons.close, color: Colors.red));
+        if (usersAnswer == correctAnswer) {
+          scoreKeeper.add(Icon(Icons.check, color: Colors.green));
+        } else {
+          scoreKeeper.add(Icon(Icons.close, color: Colors.red));
+        }
+        quizBrain.nextQuestion();
       }
-      quizBrain.nextQuestion();
     });
   }
 

--- a/lib/question.dart
+++ b/lib/question.dart
@@ -1,0 +1,9 @@
+class Question {
+  String questionText;
+  bool questionAnswer;
+
+  Question({String q, bool a}) {
+    questionText = q;
+    questionAnswer = a;
+  }
+}

--- a/lib/question.dart
+++ b/lib/question.dart
@@ -2,8 +2,5 @@ class Question {
   String questionText;
   bool questionAnswer;
 
-  Question(String q, bool a) {
-    questionText = q;
-    questionAnswer = a;
-  }
+  Question(this.questionText, this.questionAnswer);
 }

--- a/lib/question.dart
+++ b/lib/question.dart
@@ -2,7 +2,7 @@ class Question {
   String questionText;
   bool questionAnswer;
 
-  Question({String q, bool a}) {
+  Question(String q, bool a) {
     questionText = q;
     questionAnswer = a;
   }

--- a/lib/quiz_brain.dart
+++ b/lib/quiz_brain.dart
@@ -1,0 +1,61 @@
+import 'question.dart';
+
+class QuizBrain {
+  // List<String> questions = [
+  //   'You can lead a cow down stairs but not up stairs.',
+  //   'Approximately one quarter of human bones are in the feet.',
+  //   'A slug\'s blood is green.'
+  // ];
+  //
+  // List<bool> answers = [false, true, true];
+  //
+  // Question q1 = Question(
+  //   q: 'You can lead a cow down stairs but not up stairs.', a: false,
+  // );
+
+  int _questionNo = 0;
+
+  String getQuestionText() {
+    return _questionBank[_questionNo].questionText;
+  }
+
+  bool getAnswerText() {
+    return _questionBank[_questionNo].questionAnswer;
+  }
+
+  void nextQuestion() {
+    if (_questionNo < _questionBank.length - 1) {
+      _questionNo++;
+    }
+    print(_questionNo);
+    print(_questionBank.length);
+  }
+
+  List<Question> _questionBank = [
+    Question('Some cats are actually allergic to humans', true),
+    Question('You can lead a cow down stairs but not up stairs.', false),
+    Question('Approximately one quarter of human bones are in the feet.', true),
+    Question('A slug\'s blood is green.', true),
+    Question('Buzz Aldrin\'s mother\'s maiden name was \"Moon\".', true),
+    Question('It is illegal to pee in the Ocean in Portugal.', true),
+    Question(
+        'No piece of square dry paper can be folded in half more than 7 times.',
+        false),
+    Question(
+        'In London, UK, if you happen to die in the House of Parliament, you are technically entitled to a state funeral, because the building is considered too sacred a place.',
+        true),
+    Question(
+        'The loudest sound produced by any animal is 188 decibels. That animal is the African Elephant.',
+        false),
+    Question(
+        'The total surface area of two human lungs is approximately 70 square metres.',
+        true),
+    Question('Google was originally called \"Backrub\".', true),
+    Question(
+        'Chocolate affects a dog\'s heart and nervous system; a few ounces are enough to kill a small dog.',
+        true),
+    Question(
+        'In West Virginia, USA, if you accidentally hit an animal with your car, you are free to take it home to eat.',
+        true),
+  ];
+}

--- a/lib/quiz_brain.dart
+++ b/lib/quiz_brain.dart
@@ -27,8 +27,23 @@ class QuizBrain {
     if (_questionNo < _questionBank.length - 1) {
       _questionNo++;
     }
-    print(_questionNo);
-    print(_questionBank.length);
+    // print(_questionNo);
+    // print(_questionBank.length);
+  }
+
+  bool isFinished() {
+    if (_questionNo == _questionBank.length - 1) {
+      // print('isFinished Called $_questionNo');
+      return true;
+    } else {
+      return false;
+    }
+    print('isFinished Called $_questionNo');
+    // return _questionNo == 12 ? true : false;
+  }
+
+  void reset() {
+    _questionNo = 0;
   }
 
   List<Question> _questionBank = [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,8 @@ dependencies:
   flutter:
     sdk: flutter
 
+  rflutter_alert: ^2.0.2
+
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2


### PR DESCRIPTION
The flutter `create templates` for apps and plugins no longer create Android wrapping based on the v1 Android embedding as part of our gradual Android v1 embedding deprecation process.

Application projects using the v1 Android embedding are encouraged to migrate following the steps described in [Upgrading pre 1.12 Android projects](https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects).

I have made all the above required changes to the repository so that there won't be the following warning in the console any more. :D

> Warning
> ──────────────────────────────────────────────────────────────────────────────
> Your Flutter application is created using an older version of the Android
> embedding. It's being deprecated in favor of Android embedding v2. Follow the
> steps at
> 
> https://flutter.dev/go/android-project-migration
> 
> to migrate your project.
> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
> 
> Launching lib\main.dart on sdk gphone x86 arm in debug mode...
> Running Gradle task 'assembleDebug'...
> √ Built build\app\outputs\flutter-apk\app-debug.apk.
> Installing build\app\outputs\flutter-apk\app.apk...
> 