### PR TITLE
replaced deprecated flat buttons with text buttons

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -50,40 +50,41 @@ class _QuizPageState extends State<QuizPage> {
         Expanded(
           child: Padding(
             padding: EdgeInsets.all(15.0),
-            child: FlatButton(
-              textColor: Colors.white,
-              color: Colors.green,
+            child: TextButton(
+              style: TextButton.styleFrom(
+                backgroundColor: Colors.green,
+              ),
+              onPressed: (){},
               child: Text(
                 'True',
                 style: TextStyle(
                   color: Colors.white,
                   fontSize: 20.0,
-                ),
+                ) ,
               ),
-              onPressed: () {
-                //The user picked true.
-              },
-            ),
+              ),
           ),
         ),
         Expanded(
           child: Padding(
             padding: EdgeInsets.all(15.0),
-            child: FlatButton(
-              color: Colors.red,
+            child:TextButton(
+              style: TextButton.styleFrom(
+                backgroundColor:Colors.red,
+              ),
+              onPressed: (){},
               child: Text(
                 'False',
                 style: TextStyle(
-                  fontSize: 20.0,
                   color: Colors.white,
-                ),
+                  fontSize: 20.0,
+                ) ,
               ),
-              onPressed: () {
+              ),
                 //The user picked false.
-              },
+
             ),
           ),
-        ),
         //TODO: Add a Row here as your score keeper
       ],
     );


### PR DESCRIPTION
flat buttons can't be used now in flutter, they advised to use text button instead, so I updated the Yes and No buttons in Quizzler with Text Buttons with the same look as before