### PR TITLE
Remove deprecated Button reference

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -50,9 +50,8 @@ class _QuizPageState extends State<QuizPage> {
         Expanded(
           child: Padding(
             padding: EdgeInsets.all(15.0),
-            child: FlatButton(
-              textColor: Colors.white,
-              color: Colors.green,
+            child: TextButton(
+              style: ButtonStyle(backgroundColor: MaterialStateProperty.all(Colors.green)),
               child: Text(
                 'True',
                 style: TextStyle(
@@ -69,8 +68,8 @@ class _QuizPageState extends State<QuizPage> {
         Expanded(
           child: Padding(
             padding: EdgeInsets.all(15.0),
-            child: FlatButton(
-              color: Colors.red,
+            child: TextButton(
+              style: ButtonStyle(backgroundColor: MaterialStateProperty.all(Colors.red)),
               child: Text(
                 'False',
                 style: TextStyle(


### PR DESCRIPTION
Removed the deprecated button.
My cousin is doing the course via Udemy and he got stuck because he couldn't proceed any further.
I thought.. let's update it for the rest of the world that is undertaking your course.
Please accept the pull request.